### PR TITLE
build: Set up CI with Azure Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# giantbomb-extralife-nodecg
+
+> The graphics system used for Giant Bomb's Extra Life streams.
+
+As of right now, there's no docs here. Hopefully we'll write them soon!

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,210 @@
+variables:
+  # This is where things like GitHub API tokens come from.
+  - group: secure_variables
+
+  # Edit these:
+  - name: BUNDLE_NAME
+    value: 'nodecg-toth'
+  - name: NODECG_VERSION
+    value: 'v1.5.0'
+
+  # These do not need to be edited:
+  - name: PIPELINE_ARTIFACT_NAME
+    value: 'nodecg'
+  - name: TEST_SCREENSHOT_DIR
+    value: '$(Build.ArtifactStagingDirectory)/test-screenshots'
+  - name: RELATIVE_BUNDLE_ROOT
+    value: 'nodecg/bundles/$(BUNDLE_NAME)'
+  - name: ABSOLUTE_BUNDLE_ROOT
+    value: '$(Agent.BuildDirectory)/$(RELATIVE_BUNDLE_ROOT)'
+
+jobs:
+  - job: Build
+    pool:
+      vmImage: 'vs2017-win2016'
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '10.x'
+        displayName: 'Install Node.js'
+
+      - powershell: New-Item -ItemType Directory -Path $(ABSOLUTE_BUNDLE_ROOT)
+        displayName: 'create directory structure'
+
+      - script: npm install -g bower nodecg-cli polymer-cli
+        displayName: 'install global npm deps'
+
+      - script: |
+          git init
+          git remote add origin https://github.com/nodecg/nodecg.git
+          git fetch origin refs/tags/$(NODECG_VERSION):refs/tags/$(NODECG_VERSION)
+          git checkout $(NODECG_VERSION)
+          git reset
+        displayName: 'clone NodeCG'
+        workingDirectory: $(Agent.BuildDirectory)/nodecg
+
+      - checkout: self
+        path: nodecg/bundles/$(BUNDLE_NAME)
+
+      - bash: npm ci && bower install
+        displayName: 'install project npm and bower deps'
+        workingDirectory: $(ABSOLUTE_BUNDLE_ROOT)
+
+      - bash: |
+          npm run build:schemas
+          npm run lint
+          npm run build
+        displayName: 'lint & build'
+        workingDirectory: $(ABSOLUTE_BUNDLE_ROOT)
+
+      - publish: $(Agent.BuildDirectory)/nodecg
+        artifact: $(PIPELINE_ARTIFACT_NAME)
+
+  # ------ #
+
+  - job: create_prebuilds
+    strategy:
+      matrix:
+        linux:
+          imageName: 'ubuntu-16.04'
+        mac:
+          imageName: 'macos-10.13'
+        windows:
+          imageName: 'vs2017-win2016'
+    pool:
+      vmImage: $(imageName)
+    dependsOn: build
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '10.x'
+        displayName: 'Install Node.js'
+
+      - checkout: none
+
+      - download: current
+        artifact: $(PIPELINE_ARTIFACT_NAME)
+        patterns: |
+          **
+          !**/node_modules/**
+
+      - bash: |
+          # Linux needs sudo.
+          export $run_as=""
+          if [ "$(Agent.OS)" = "Linux" ]; then
+            $run_as="sudo"
+          fi
+
+          $run_as npm ci --production
+          cd ../..
+          $run_as npm ci --production
+        displayName: 'install prod deps (and remove dev deps)'
+        workingDirectory: $(Pipeline.Workspace)/$(PIPELINE_ARTIFACT_NAME)/bundles/$(BUNDLE_NAME)
+
+      # Used by the next step.
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.7'
+
+      - bash: |
+          pip install --upgrade setuptools wheel grip
+
+          mkdir ~/.grip
+          echo "PASSWORD = '$(GITHUB_TOKEN)'" > ~/.grip/settings.py
+
+          mkdir -p $(Build.ArtifactStagingDirectory)/pkg
+          grip README.md --export README.html
+        workingDirectory: $(Pipeline.Workspace)/$(PIPELINE_ARTIFACT_NAME)/bundles/$(BUNDLE_NAME)
+        displayName: 'Render Bundle README to HTML'
+
+      - task: CopyFiles@2
+        inputs:
+          sourceFolder: $(Pipeline.Workspace)/$(PIPELINE_ARTIFACT_NAME)/bundles/$(BUNDLE_NAME)
+          targetFolder: $(Build.ArtifactStagingDirectory)/zip_contents
+          contents: |
+            README.md
+            README.html
+            obs-assets/**
+        displayName: 'Copy README and obs-assets to top-level dir'
+
+      - task: DeleteFiles@1
+        inputs:
+          sourceFolder: $(Pipeline.Workspace)/$(PIPELINE_ARTIFACT_NAME)
+          contents: |
+            **/README.{md,html}
+            **/{obs-assets,.git,test}/**
+        displayName: 'shrink pkg size by removing redundant or unnecessary files'
+
+      - bash: |
+          if [ "$(Agent.OS)" = "Windows_NT" ]; then
+            node_name="node.exe"
+          else
+            node_name="node"
+          fi
+          echo "node_name = $node_name"
+          echo "which node_name = $(which $node_name)"
+          cp "$(which $node_name)" "$node_name"
+        displayName: 'Copy Node executable'
+
+      - bash: |
+          if [ "$(Agent.OS)" = "Windows_NT" ]; then
+            printf "node.exe $(PIPELINE_ARTIFACT_NAME)/index.js\n@pause" >> "nodecg.bat"
+          else
+            printf "./node $(PIPELINE_ARTIFACT_NAME)/index.js\nread -n 1 -s -r -p "Press any key to continue"" >> "nodecg.sh"
+          fi
+        workingDirectory: $(Build.ArtifactStagingDirectory)/zip_contents
+        displayName: 'Create launcher script'
+
+      - bash: |
+          mkdir -p cfg
+
+          # Interesting way of writing a multi-line file in bash:
+          # https://stackoverflow.com/a/18226936
+          cat <<EOM > cfg/nodecg.json
+          {
+           "logging": {
+             "console": {
+               "level": "info"
+             },
+             "file": {
+               "enabled": true,
+               "level": "debug"
+             },
+             "replicants": false
+           }
+          }
+          EOM
+        workingDirectory: $(Pipeline.Workspace)/$(PIPELINE_ARTIFACT_NAME)
+        displayName: 'Create top-level nodecg config'
+
+      - bash: |
+          echo [InternetShortcut] > "GitHub Repo.URL"
+          echo URL=https://github.com/$(Build.Repository.Name) >> "GitHub Repo.URL"
+          echo IconFile=https://github.com/favicon.ico >> "GitHub Repo.URL"
+          echo IconIndex=0 >> "GitHub Repo.URL"
+        workingDirectory: $(Build.ArtifactStagingDirectory)/zip_contents
+        displayName: "Create a URL shortcut to the repo's page on GitHub"
+
+      - pwsh: |
+          $short_hash = "$(-join '$(Build.SourceVersion)'[0..7])"
+          echo "short_hash $short_hash"
+          echo "##vso[task.setvariable variable=SHORT_COMMIT_HASH]$short_hash"
+        displayName: 'Compute short commit hash (for use in Artifact name)'
+
+      - task: ArchiveFiles@2
+        inputs:
+          rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/zip_contents'
+          includeRootFolder: false
+          archiveType: 'zip'
+          archiveFile: '$(Build.ArtifactStagingDirectory)/$(BUNDLE_NAME)-$(SHORT_COMMIT_HASH)-$(Agent.OS).zip'
+
+      - task: ArchiveFiles@2
+        inputs:
+          rootFolderOrFile: '$(Pipeline.Workspace)/$(PIPELINE_ARTIFACT_NAME)'
+          includeRootFolder: true
+          archiveType: 'zip'
+          archiveFile: '$(Build.ArtifactStagingDirectory)/$(BUNDLE_NAME)-$(SHORT_COMMIT_HASH)-$(Agent.OS).zip'
+          replaceExistingArchive: false
+
+      - publish: '$(Build.ArtifactStagingDirectory)/$(BUNDLE_NAME)-$(SHORT_COMMIT_HASH)-$(Agent.OS).zip'
+        artifact: $(Agent.OS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
         displayName: 'install global npm deps'
 
       - script: |
+          set -e && set -o pipefail
           git init
           git remote add origin https://github.com/nodecg/nodecg.git
           git fetch origin refs/tags/$(NODECG_VERSION):refs/tags/$(NODECG_VERSION)
@@ -51,6 +52,7 @@ jobs:
         workingDirectory: $(ABSOLUTE_BUNDLE_ROOT)
 
       - bash: |
+          set -e && set -o pipefail
           npm run build:schemas
           npm run static
           npm run build
@@ -89,6 +91,8 @@ jobs:
           !**/node_modules/**
 
       - bash: |
+          set -e && set -o pipefail
+
           # Linux needs sudo.
           export $run_as=""
           if [ "$(Agent.OS)" = "Linux" ]; then
@@ -107,6 +111,7 @@ jobs:
           versionSpec: '3.7'
 
       - bash: |
+          set -e && set -o pipefail
           pip install --upgrade setuptools wheel grip
 
           mkdir ~/.grip
@@ -136,6 +141,7 @@ jobs:
         displayName: 'shrink pkg size by removing redundant or unnecessary files'
 
       - bash: |
+          set -e && set -o pipefail
           if [ "$(Agent.OS)" = "Windows_NT" ]; then
             node_name="node.exe"
           else
@@ -147,6 +153,7 @@ jobs:
         displayName: 'Copy Node executable'
 
       - bash: |
+          set -e && set -o pipefail
           if [ "$(Agent.OS)" = "Windows_NT" ]; then
             printf "node.exe $(PIPELINE_ARTIFACT_NAME)/index.js\n@pause" >> "nodecg.bat"
           else
@@ -156,6 +163,7 @@ jobs:
         displayName: 'Create launcher script'
 
       - bash: |
+          set -e && set -o pipefail
           mkdir -p cfg
 
           # Interesting way of writing a multi-line file in bash:
@@ -178,6 +186,7 @@ jobs:
         displayName: 'Create top-level nodecg config'
 
       - bash: |
+          set -e && set -o pipefail
           echo [InternetShortcut] > "GitHub Repo.URL"
           echo URL=https://github.com/$(Build.Repository.Name) >> "GitHub Repo.URL"
           echo IconFile=https://github.com/favicon.ico >> "GitHub Repo.URL"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,16 +92,9 @@ jobs:
 
       - bash: |
           set -e && set -o pipefail
-
-          # Linux needs sudo.
-          run_as=""
-          if [ "$(Agent.OS)" = "Linux" ]; then
-            run_as="sudo"
-          fi
-
-          $run_as npm ci --production
+          npm ci --production
           cd ../..
-          $run_as npm ci --production
+          npm ci --production
         displayName: 'install prod deps (and remove dev deps)'
         workingDirectory: $(Pipeline.Workspace)/$(PIPELINE_ARTIFACT_NAME)/bundles/$(BUNDLE_NAME)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
       - powershell: New-Item -ItemType Directory -Path $(ABSOLUTE_BUNDLE_ROOT)
         displayName: 'create directory structure'
 
-      - script: npm install -g bower nodecg-cli polymer-cli
+      - script: npm install -g bower nodecg-cli
         displayName: 'install global npm deps'
 
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
       - powershell: New-Item -ItemType Directory -Path $(ABSOLUTE_BUNDLE_ROOT)
         displayName: 'create directory structure'
 
-      - script: npm install -g bower nodecg-cli
+      - script: npm install -g nodecg-cli
         displayName: 'install global npm deps'
 
       - script: |
@@ -46,8 +46,8 @@ jobs:
       - checkout: self
         path: nodecg/bundles/$(BUNDLE_NAME)
 
-      - bash: npm ci && bower install
-        displayName: 'install project npm and bower deps'
+      - bash: npm ci
+        displayName: 'install project npm'
         workingDirectory: $(ABSOLUTE_BUNDLE_ROOT)
 
       - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 
   # Edit these:
   - name: BUNDLE_NAME
-    value: 'nodecg-toth'
+    value: 'giantbomb-extralife-nodecg'
   - name: NODECG_VERSION
     value: 'v1.5.0'
 
@@ -52,7 +52,7 @@ jobs:
 
       - bash: |
           npm run build:schemas
-          npm run lint
+          npm run static
           npm run build
         displayName: 'lint & build'
         workingDirectory: $(ABSOLUTE_BUNDLE_ROOT)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,9 +94,9 @@ jobs:
           set -e && set -o pipefail
 
           # Linux needs sudo.
-          export $run_as=""
+          run_as=""
           if [ "$(Agent.OS)" = "Linux" ]; then
-            $run_as="sudo"
+            run_as="sudo"
           fi
 
           $run_as npm ci --production

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "giantbomb-extralife",
+  "name": "giantbomb-extralife-nodecg",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -121,8 +121,7 @@
     "alea": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/alea/-/alea-0.0.9.tgz",
-      "integrity": "sha1-9zjLRfg0MAafRc9pzL8xLdV6nho=",
-      "dev": true
+      "integrity": "sha1-9zjLRfg0MAafRc9pzL8xLdV6nho="
     },
     "ansi-align": {
       "version": "1.1.0",
@@ -650,7 +649,6 @@
     "extra-life-api-mock": {
       "version": "github:LtSquigs/extra-life-api-mock#43930d0287e0104081cac04954f3cc6c6b169867",
       "from": "github:LtSquigs/extra-life-api-mock",
-      "dev": true,
       "requires": {
         "lorem-ipsum": "^1.0.6",
         "moment": "^2.24.0",
@@ -1153,7 +1151,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.6.tgz",
       "integrity": "sha512-Rx4XH8X4KSDCKAVvWGYlhAfNqdUP5ZdT4rRyf0jjrvWgtViZimDIlopWNfn/y3lGM5K4uuiAoY28TaD+7YKFrQ==",
-      "dev": true,
       "requires": {
         "minimist": "~1.2.0"
       }
@@ -1238,8 +1235,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1261,8 +1257,7 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mount-point": {
       "version": "3.0.0",
@@ -1299,7 +1294,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/node-random-name/-/node-random-name-1.0.1.tgz",
       "integrity": "sha1-niQEx6AeCQWi92Fogh7bLc0U91g=",
-      "dev": true,
       "requires": {
         "alea": "0.0.9"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -642,8 +642,8 @@
       }
     },
     "extra-life-api-mock": {
-      "version": "git+ssh://git@github.com/LtSquigs/extra-life-api-mock.git#465e20794ae380f353ba5fbc6bada6195288ae1b",
-      "from": "git+ssh://git@github.com/LtSquigs/extra-life-api-mock.git",
+      "version": "github:LtSquigs/extra-life-api-mock#43930d0287e0104081cac04954f3cc6c6b169867",
+      "from": "github:LtSquigs/extra-life-api-mock",
       "dev": true,
       "requires": {
         "lorem-ipsum": "^1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,12 @@
         "@supportclass/tsconfig-base": "^1.0.2"
       }
     },
+    "@types/node": {
+      "version": "12.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
+      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "giantbomb-extralife",
+  "name": "giantbomb-extralife-nodecg",
   "version": "0.0.1",
   "description": "Giant Bomb Extra Life Layouts",
   "main": "extensions.js",

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "@supportclass/tsconfig-base": "^1.0.2",
     "@supportclass/tsconfig-nodecg-client": "^1.0.2",
     "@supportclass/tsconfig-nodecg-server": "^1.0.2",
+    "@types/node": "^12.7.4",
     "extra-life-api-mock": "github:LtSquigs/extra-life-api-mock",
     "npm-run-all": "^4.1.5",
     "trash-cli": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@supportclass/tsconfig-base": "^1.0.2",
     "@supportclass/tsconfig-nodecg-client": "^1.0.2",
     "@supportclass/tsconfig-nodecg-server": "^1.0.2",
-    "extra-life-api-mock": "git+ssh://git@github.com/LtSquigs/extra-life-api-mock.git",
+    "extra-life-api-mock": "github:LtSquigs/extra-life-api-mock",
     "npm-run-all": "^4.1.5",
     "trash-cli": "^1.4.0",
     "tslint": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "homepage": "https://github.com/LtSquigs/giantbomb-extralife-nodecg#readme",
   "dependencies": {
-    "extra-life-api": "^5.2.0"
+    "extra-life-api": "^5.2.0",
+    "extra-life-api-mock": "github:LtSquigs/extra-life-api-mock"
   },
   "nodecg": {
     "compatibleRange": "^1.3.0",
@@ -173,7 +174,6 @@
     "@supportclass/tsconfig-nodecg-client": "^1.0.2",
     "@supportclass/tsconfig-nodecg-server": "^1.0.2",
     "@types/node": "^12.7.4",
-    "extra-life-api-mock": "github:LtSquigs/extra-life-api-mock",
     "npm-run-all": "^4.1.5",
     "trash-cli": "^1.4.0",
     "tslint": "^5.12.1",


### PR DESCRIPTION
Ready to merge. This creates easy-to-run zip files for macOS, Linux, and Windows. These zips get stored as build artifacts on azure pipelines. To download, do the following:

- [Navigate to the build list](https://dev.azure.com/giantbomb-extralife/giantbomb-extralife-nodecg/_build?definitionId=1&_a=summary)
- Click on the build you'd like to download
- Click the blue artifacts button in the top right
- Select the OS you want in the dropdown (these OS names come from Azure Pipelines and I can't control them easily, hence why macOS is listed as Darwin)
- A dialog box will pop up with a folder icon and the OS name next to it
- Click the little arrow next to the folder icon to expand the folder. You may have to click twice because internet
- You should now see the actual zip archive
- Click to the right of it on the 3 little dots to get the download link. You may have to click twice because internet

In addition, this also runs our "tests" (which is just linting and running the TS compiler) and makes sure things at least build. I've also added a required status check to github here so that it will yell at us if we try to merge something that is failing builds.